### PR TITLE
Updated redis monitor script

### DIFF
--- a/redis-monitor
+++ b/redis-monitor
@@ -83,7 +83,7 @@ monitor_cleanup() {
 monitor_report() {
     # First argument is irrelevant.
     shift
-    docker run --rm -it --name redis_monitor_report --network=$NETWORK dicix/redis_monitor_report python report.py $@
+    docker run --rm -it --name redis_monitor_report --network=$NETWORK $(whoami)/redis_monitor_report python report.py $@
 }
 
 ################################


### PR DESCRIPTION
Replaced dicix with $(whoami) in line 86 it failed monitor_report when installed in a different user